### PR TITLE
fix(deps): make minimist a runtime dependency

### DIFF
--- a/bin/aws-cloudformation-wait-ready.js
+++ b/bin/aws-cloudformation-wait-ready.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 const parseArgs = require("minimist");
 const { CloudFormation } = require("aws-sdk");
 const process = require("process");

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.536.0",
-    "chalk": "^3.0.0"
+    "chalk": "^3.0.0",
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5168,6 +5168,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"


### PR DESCRIPTION
## Summary

Includes minimist as a runtime dependency so that the package is executable using `npx` which doesn't install `devDependencies`

## Dependencies

None

## Changes
### Interface 

No changes to interface.

### Developer

None except minimist will be installed when executed with `npx` which does not include `devDependencies`.

## Details

Right now this is not executable with `npx` which does not install `devDependencies`:

![](https://d.pr/i/S3VRjc.png)

## Testing

```
yarn
yarn run build
yarn --prod # prunes non-prod dependencies
yarn aws-cloudformation-wait-ready --region us-east-1 --stack-name YourStackName
```

E.g.:

![](https://d.pr/i/7N2vlu.png)