### PR TITLE
Upgrade  to finish resolving CVE-2017-16137

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,7 +1735,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
   integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2547,10 +2547,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -2565,13 +2565,6 @@ debug@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -5285,7 +5278,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
# Summary
## What does this PR do?
- Finish resolving CVE-2017-16137
  | Affected versions | Patched versions |
  |-|-|
  | < 2.6.9 | 2.6.9 |
  | >= 3.0.0, < 3.1.0 | 3.1.0 |
  | >= 3.2.0, < 3.2.7 | 3.2.7 |
  | >= 4.0.0, < 4.3.1 | 4.3.1 |
```zsh
   - Hoisted from "@babel#core#debug"
   - Hoisted from "@babel#preset-env#@babel#plugin-proposal-async-generator-functions#@babel#helper-remap-async-to-generator#@babel#helper-wrap-function#@babel#traverse#debug"
   - Hoisted from "@babel#preset-env#@babel#plugin-proposal-async-generator-functions#@babel#helper-remap-async-to-generator#@babel#traverse#debug"
   - Hoisted from "@babel#preset-env#@babel#plugin-transform-exponentiation-operator#@babel#helper-builder-binary-assignment-operator-visitor#@babel#helper-explode-assignable-expression#@babel#traverse#debug"
   - Hoisted from "@babel#preset-env#@babel#plugin-transform-parameters#@babel#helper-call-delegate#@babel#traverse#debug"
   - Hoisted from "@babel#traverse#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#babel-eslint#@babel#traverse#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#@eslint#eslintrc#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#@humanwhocodes#config-array#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#debug"
   - Hoisted from "@jest#transform#@babel#core#debug"
   - Hoisted from "babel-eslint#@babel#traverse#debug"
   - Hoisted from "babel-jest#@jest#transform#@babel#core#debug"
   - Hoisted from "babel-plugin-istanbul#istanbul-lib-instrument#@babel#traverse#debug"
   - Hoisted from "eslint#debug"
   - Hoisted from "jest#@jest#core#@jest#reporters#istanbul-lib-instrument#@babel#core#debug"
   - Hoisted from "jest#@jest#core#@jest#reporters#istanbul-lib-source-maps#debug"
   - Hoisted from "jest#@jest#core#jest-config#@babel#core#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#agent-base#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#https-proxy-agent#debug"
[1/4] Why do we have the module "debug"...?
info => Found "debug@4.3.4"
info => Found "eslint-import-resolver-node#debug@2.6.9"
info => Found "eslint-module-utils#debug@2.6.9"
info => Found "eslint-plugin-import#debug@2.6.9"
info => Found "expand-brackets#debug@2.6.9"
info => Found "license-checker#debug@3.2.7"
info => Found "snapdragon#debug@2.6.9"
info Has been hoisted to "debug"
```

# Testing
## How can the other reviewers check that your change works?
build should pass
