### PR TITLE
Upgrade `ws` to resolve CVE-2024-37890

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7386,10 +7386,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^7.4.6:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
-  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+ws@^7.4.6, ws@^7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Summary
## What does this PR do?
- Bump `ws` package to resolve CVE-2024-37890
  | Affected versions | Patched versions |
  |-|-|
  | < 7.5.10 | 7.5.10 |

### Before
```zsh
yarn why ws
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#ws"
[1/4] Why do we have the module "ws"...?
info => Found "ws@7.5.6"



```

### After
```zsh
yarn why ws
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#ws"
[1/4] Why do we have the module "ws"...?
info => Found "ws@7.5.10"


=
```

# Testing
## How can the other reviewers check that your change works?
build should pass
