### PR TITLE
fix: revert to use require in script

### DIFF
--- a/bin/aws-cloudformation-wait-ready.js
+++ b/bin/aws-cloudformation-wait-ready.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
-import parseArgs from "minimist";
-import { CloudFormation } from "aws-sdk";
-// eslint-disable-next-line import/extensions
-import cfnWaitReady from "../lib/index.js";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const parseArgs = require("minimist");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { CloudFormation } = require("aws-sdk");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const cfnWaitReady = require("../lib").default;
 
 const args = parseArgs(process.argv.slice(2), {
   alias: {


### PR DESCRIPTION
## Summary
What does this PR do?
- closes #50 

## Testing
How can the other reviewers check that your change works?
- I recreated the error by running the script in `master` locally
- I made the fix and no longer get the error